### PR TITLE
Expose fetch function for custom grants

### DIFF
--- a/projects/lib/src/types.ts
+++ b/projects/lib/src/types.ts
@@ -104,6 +104,7 @@ export interface ParsedIdToken {
  * http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
  */
 export interface TokenResponse {
+  id_token?: string;
   access_token: string;
   token_type: string;
   expires_in: number;


### PR DESCRIPTION
Expose `fetchTokenUsingGrant` which can be used to send custom grant
requests to the token endpoint. The password flow then becomes just a
wrapper around that, where username and password are passed to the
request.

- Add `id_token` to `TokenResponse` type since this is part of the OIDC
  spec. Add handling for the ID token, so that it gets processed and
  stored properly.
- Simplify `http.post` call by using `toPromise()` to convert Rx
  observable into a promise.